### PR TITLE
PhoneNumberHelper: formatNumber: check if isEmpty

### DIFF
--- a/src/com/android/contacts/common/util/PhoneNumberHelper.java
+++ b/src/com/android/contacts/common/util/PhoneNumberHelper.java
@@ -118,8 +118,10 @@ public class PhoneNumberHelper {
      * is made public.
      */
     public static String formatNumber(String phoneNumber, String defaultCountryIso) {
-        // Do not attempt to format numbers that start with a hash or star symbol.
-        if (phoneNumber.startsWith("#") || phoneNumber.startsWith("*")) {
+        // Do not attempt to format numbers that are empty or start with a hash
+        // or star symbol.
+        if (TextUtils.isEmpty(phoneNumber) || phoneNumber.startsWith("#") ||
+                phoneNumber.startsWith("*")) {
             return phoneNumber;
         }
 


### PR DESCRIPTION
If formatNumber is invoked with an empty number, then there's no
formatting to be done. This patch avoids an NPE while trying to parse
an inexistent string.

Change-Id: Ic7a9dd3d1e0e7b27457f59f1209387b7faa359d9